### PR TITLE
Add validation check to ensure valid image domain of [0.0, 1.0]

### DIFF
--- a/common/framework.py
+++ b/common/framework.py
@@ -227,6 +227,15 @@ class LpTask(TaskDefinition):
         if distortion > self.threshold + 1e-3:
             return False, "Distortion {} exceeds bound {}".format(distortion, self.threshold)
 
+        # Verify that example is within [0, 1] domain of input images
+        min_val = np.min(adv_example)
+        max_val = np.max(adv_example)
+        if min_val < 0.0:
+            return False, "Adversarial example min value {} is outside of [0, 1] range".format(min_val)
+        if max_val > 1.0:
+            return False, "Adversarial example max value {} is outside of [0, 1] range".format(max_val)
+
+
         # Verify that it's not detected as adversarial
         if adv_detector > defense.threshold:
             return False, "Adversarial example rejected by detector with score {}.".format(adv_detector)

--- a/common/framework.py
+++ b/common/framework.py
@@ -235,7 +235,6 @@ class LpTask(TaskDefinition):
         if max_val > 1.0:
             return False, "Adversarial example max value {} is outside of [0, 1] range".format(max_val)
 
-
         # Verify that it's not detected as adversarial
         if adv_detector > defense.threshold:
             return False, "Adversarial example rejected by detector with score {}.".format(adv_detector)


### PR DESCRIPTION
I had forgotten to clip this in a couple of my attacks. For instance, on the blur defense, I got it down to 7% failures with a simple PGD-20 attack, but forgot to clip inputs, so many of the values were outside this range. With this check added, I had 54% failures. With properly clipping, I was able to bring it down to 8% failures with the same attack.

In general, I don't expect this to be a serious issue for Linf attacks with small epsilon, but will certainly be a big issue for L2 attacks.